### PR TITLE
fixed bug #6 with switch not toggling with state prop update

### DIFF
--- a/src/coffee/react-bootstrap-switch.coffee
+++ b/src/coffee/react-bootstrap-switch.coffee
@@ -32,6 +32,9 @@ module.exports = React.createClass
     readonly: @_prop('readonly')
     indeterminate: @_prop('indeterminate')
 
+  componentWillReceiveProps: (nextProps) ->
+    this.value(nextProps.state)
+
   _prop: (key) ->
     if typeof @props[key] == 'undefined'
       @defaults[key]


### PR DESCRIPTION
Relates to #6 

Previously when the `state` prop changed due to an update in the parent component, the switch would not toggle to the correct position.  Now, with the use of `componentWillReceiveProps`, we pass the `state` prop to the `value()` method so it can be updated.

This method will probably work with other, currently immutable props.

Have confirmed this works by modifying the vanilla JS compiled version in my `node_modules` folder.
