### PR TITLE
Fix issue with onColor when not focused.

### DIFF
--- a/src/less/bootstrap3/react-bootstrap-switch.less
+++ b/src/less/bootstrap3/react-bootstrap-switch.less
@@ -99,6 +99,7 @@
     margin: 0;
     z-index: -1;
     .opacity(0);
+    visibility: hidden;
   }
 
   &.@{bootstrap-switch-base}-mini {


### PR DESCRIPTION
In Safari, even with the opacity set to zero, the unfocused ON state `onColor` is only shown as a small square in the upper left hand corner of the on switch. Setting the checkbox visibility to `hidden` fixes the issue.
