### PR TITLE
Made it so that changes to disabled prop are rendered

### DIFF
--- a/src/coffee/react-bootstrap-switch.coffee
+++ b/src/coffee/react-bootstrap-switch.coffee
@@ -35,6 +35,7 @@ module.exports = React.createClass
 
   componentWillReceiveProps: (nextProps) ->
     this.value(nextProps.state)
+    this.disabled(nextProps.disabled) if nextProps.disabled === true or nextProps.disabled === false
 
   _prop: (key) ->
     if typeof @props[key] == 'undefined'


### PR DESCRIPTION
Currently when you change the disabled prop, the change isn't registered.  This makes the switch useless when combined with redux and trying to disable or enable switches dynamically.

This PR makes it so you can enable or disable a switch dynamically.
