### PR TITLE
disabled and readonly fix for state redefinition

### DIFF
--- a/src/coffee/react-bootstrap-switch.coffee
+++ b/src/coffee/react-bootstrap-switch.coffee
@@ -45,7 +45,7 @@ module.exports = React.createClass
 
   value: (val, nextProps = {}) ->
     disabled = if typeof nextProps.disabled is "undefined" then @state.disabled else nextProps.disabled
-    readonly = if typeof nextProps.readonly is "undefined" then @state.disabled else nextProps.readonly
+    readonly = if typeof nextProps.readonly is "undefined" then @state.readonly else nextProps.readonly
 
     return @state.state  if typeof val is "undefined"
     return @  if disabled or readonly

--- a/src/coffee/react-bootstrap-switch.coffee
+++ b/src/coffee/react-bootstrap-switch.coffee
@@ -35,7 +35,7 @@ module.exports = React.createClass
 
   componentWillReceiveProps: (nextProps) ->
     this.disabled(!!nextProps.disabled)
-    this.value(nextProps.state)
+    this.value(nextProps.state, nextProps)
 
   _prop: (key) ->
     if typeof @props[key] == 'undefined'
@@ -43,9 +43,12 @@ module.exports = React.createClass
     else
       @props[key]
 
-  value: (val) ->
+  value: (val, nextProps = {}) ->
+    disabled = if typeof nextProps.disabled is "undefined" then @state.disabled else nextProps.disabled
+    readonly = if typeof nextProps.readonly is "undefined" then @state.disabled else nextProps.readonly
+
     return @state.state  if typeof val is "undefined"
-    return @  if @state.disabled or @state.readonly
+    return @  if disabled or readonly
 
     return @ if @state.state == val
 


### PR DESCRIPTION
State1:
Passing properties to Switch component:
state={true}
disabled={true}

State2:
Passing properties to Switch component:
state={false}
disabled={false}

The outcome: state property has true value and expectations are the opposite. The same applies for readonly. I assume that 'disabled' means that user is not able to change value. But value still can be changed. Imagine following scenario:

1) User presses Switch component
2) AJAX request fired. Switch component becomes disabled, so user is not able to change it value again while request is not over
3) AJAX request finished successfully, we are changing state of the component and removing disabled prop.

Without provided fix component is not updating state on p.3
