### PR TITLE
Added a 'tristate' switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ These should be defined on the JSX node, many cannot be changed once they have b
 | **disabled**      | boolean | false     | true, false | Disable state |
 | **readonly**      | boolean | false     | true, false | Readonly state |
 | **inverse**       | boolean | false     | true, false | Inverse switch direction|
+| **tristate**      | boolean | false     | true, false | Allows user to cycle values through true, false and null |
 | **onColor**       | string  | 'primary' | 'primary', 'info', 'success', 'warning', 'danger', 'default' | Color of the on side of the switch |
 | **offColor**      | string  | 'default' | 'primary', 'info', 'success', 'warning', 'danger', 'default' | Color of the off side of the switch |
 | **onText**        | string  | 'ON'      | | Text of the on side of the switch |

--- a/dist/js/index.js
+++ b/dist/js/index.js
@@ -28,7 +28,7 @@ var Switch = function (_React$Component) {
   function Switch(props) {
     _classCallCheck(this, Switch);
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(Switch).call(this, props));
+    var _this = _possibleConstructorReturn(this, (Switch.__proto__ || Object.getPrototypeOf(Switch)).call(this, props));
 
     _this.state = {
       offset: null,
@@ -87,6 +87,7 @@ var Switch = function (_React$Component) {
       var disabled = _props.disabled;
       var readonly = _props.readonly;
       var inverse = _props.inverse;
+      var tristate = _props.tristate;
       var animate = _props.animate;
       var id = _props.id;
       var _state = this.state;
@@ -109,6 +110,8 @@ var Switch = function (_React$Component) {
       if (value === null) classes.push(baseClass + "-indeterminate");
 
       if (inverse) classes.push(baseClass + "-inverse");
+
+      if (tristate) classes.push(baseClass + "-tristate");
 
       if (id) classes.push(baseClass + "-" + id);
 
@@ -186,7 +189,7 @@ var Switch = function (_React$Component) {
     value: function _handleOnClick() {
       if (this._disableUserInput()) return;
 
-      this._setValue(false);
+      this._setValue(this.props.tristate ? this._getValue() == null : false);
       this._setFocus();
     }
   }, {
@@ -194,7 +197,7 @@ var Switch = function (_React$Component) {
     value: function _handleOffClick() {
       if (this._disableUserInput()) return;
 
-      this._setValue(true);
+      this._setValue(this.props.tristate ? this._getValue() != null : true);
       this._setFocus();
     }
   }, {
@@ -257,14 +260,20 @@ var Switch = function (_React$Component) {
 
       if (dragStart === undefined || dragStart === null || dragStart === false) return;
 
-      var inverse = this.props.inverse;
+      var _props4 = this.props;
+      var inverse = _props4.inverse;
+      var tristate = _props4.tristate;
 
 
-      var val = !value;
+      var val = void 0;
 
       if (dragged) {
         val = offset > -(handleWidth / 2);
         val = inverse ? !val : val;
+      } else if (tristate) {
+        val = value === null ? true : value ? false : null;
+      } else {
+        val = !value;
       }
 
       this.setState({
@@ -323,9 +332,9 @@ var Switch = function (_React$Component) {
   }, {
     key: 'render',
     value: function render() {
-      var _props4 = this.props;
-      var baseClass = _props4.baseClass;
-      var inverse = _props4.inverse;
+      var _props5 = this.props;
+      var baseClass = _props5.baseClass;
+      var inverse = _props5.inverse;
       var _state5 = this.state;
       var handleWidth = _state5.handleWidth;
       var labelWidth = _state5.labelWidth;
@@ -370,10 +379,10 @@ var Switch = function (_React$Component) {
     value: function _renderOnHandle() {
       var _this7 = this;
 
-      var _props5 = this.props;
-      var baseClass = _props5.baseClass;
-      var onColor = _props5.onColor;
-      var onText = _props5.onText;
+      var _props6 = this.props;
+      var baseClass = _props6.baseClass;
+      var onColor = _props6.onColor;
+      var onText = _props6.onText;
       var handleWidth = this.state.handleWidth;
 
 
@@ -397,10 +406,10 @@ var Switch = function (_React$Component) {
     value: function _renderOffHandle() {
       var _this8 = this;
 
-      var _props6 = this.props;
-      var baseClass = _props6.baseClass;
-      var offColor = _props6.offColor;
-      var offText = _props6.offText;
+      var _props7 = this.props;
+      var baseClass = _props7.baseClass;
+      var offColor = _props7.offColor;
+      var offText = _props7.offText;
       var handleWidth = this.state.handleWidth;
 
 
@@ -424,9 +433,9 @@ var Switch = function (_React$Component) {
     value: function _renderLabel() {
       var _this9 = this;
 
-      var _props7 = this.props;
-      var baseClass = _props7.baseClass;
-      var labelText = _props7.labelText;
+      var _props8 = this.props;
+      var baseClass = _props8.baseClass;
+      var labelText = _props8.labelText;
       var labelWidth = this.state.labelWidth;
 
 
@@ -482,6 +491,7 @@ Switch.defaultProps = {
   disabled: false,
   readonly: false,
 
+  tristate: false,
   defaultValue: true,
   value: undefined
 };
@@ -507,6 +517,7 @@ Switch.propTypes = {
   disabled: _react2.default.PropTypes.bool,
   readonly: _react2.default.PropTypes.bool,
 
+  tristate: _react2.default.PropTypes.bool,
   defaultValue: _react2.default.PropTypes.bool,
   value: _react2.default.PropTypes.bool,
   onChange: _react2.default.PropTypes.func

--- a/dist/js/index.js
+++ b/dist/js/index.js
@@ -271,7 +271,7 @@ var Switch = function (_React$Component) {
         val = offset > -(handleWidth / 2);
         val = inverse ? !val : val;
       } else if (tristate) {
-        val = value === null ? true : value ? false : null;
+        val = value === null ? true : null;
       } else {
         val = !value;
       }

--- a/example/src/example.js
+++ b/example/src/example.js
@@ -6,6 +6,7 @@ import { InternalState } from './internal-state';
 import { ExternalState } from './external-state';
 import { Disabled } from './disabled';
 import { Inverse } from './inverse';
+import { Tristate } from './tristate';
 import { OnText } from './on-text';
 import { OffText } from './off-text';
 import { HandleWidth } from './handle-width';
@@ -46,6 +47,8 @@ class Examples extends React.Component {
           <Indeterminate />
           <HandleWidth />
           <LabelWidth />
+          
+          <Tristate />
         </Row>
       </Grid>
     );

--- a/example/src/tristate.js
+++ b/example/src/tristate.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Col, Button, ButtonGroup, FormGroup } from 'react-bootstrap';
+
+import Switch from '../../src/js/index';
+
+export class Tristate extends React.Component {
+
+  _clickToggle(){
+    const val = this.switch.value();
+    this.switch.value(!val);
+  }
+  _clickOn(){ 
+    this.switch.value(true);
+  }
+  _clickOff(){
+    this.switch.value(false);
+  }
+  _clickGet(){
+    alert(this.switch.value());
+  }
+
+  render(){
+    return (
+      <Col xs={6} md={4}>
+        <h3>Tristate</h3>
+
+        <form>
+          <FormGroup>
+            <Switch ref={e => this.switch = e} tristate={true} defaultValue={null}/>
+          </FormGroup>
+
+          <FormGroup>
+            <ButtonGroup>
+              <Button onClick={this._clickToggle.bind(this)} >Toggle</Button>
+              <Button onClick={this._clickOn.bind(this)} >On</Button>
+              <Button onClick={this._clickOff.bind(this)} >Off</Button>
+              <Button onClick={this._clickGet.bind(this)} >Get</Button>
+            </ButtonGroup>
+          </FormGroup>
+        </form>
+      </Col>
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-bootstrap-switch",
   "description": "Turn checkboxes and radio buttons into toggle switches.",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "keywords": [
     "react",
     "bootstrap",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -159,7 +159,7 @@ export default class Switch extends React.Component {
     if(this._disableUserInput())
       return;
 
-    this._setValue(false)
+    this._setValue(this.props.tristate?(this._getValue()==null):false);
     this._setFocus();
   }
 
@@ -167,7 +167,7 @@ export default class Switch extends React.Component {
     if(this._disableUserInput())
       return;
 
-    this._setValue(true)
+   	this._setValue(this.props.tristate?(this._getValue()!=null):true);
     this._setFocus();
   }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -56,6 +56,7 @@ export default class Switch extends React.Component {
       disabled,
       readonly,
       inverse,
+      tristate,
       animate,
       id
     } = this.props;
@@ -84,7 +85,10 @@ export default class Switch extends React.Component {
       classes.push(baseClass + "-indeterminate");
 
     if (inverse)
-      classes.push(baseClass + "-inverse");
+        classes.push(baseClass + "-inverse");
+
+    if (tristate)
+        classes.push(baseClass + "-tristate");
 
     if (id)
       classes.push(baseClass + "-" + id);
@@ -216,13 +220,17 @@ export default class Switch extends React.Component {
     if(dragStart === undefined || dragStart === null || dragStart === false)
       return;
 
-    const { inverse } = this.props;
+    const { inverse, tristate } = this.props;
 
-    let val = !value;
-
+    let val;
+    
     if(dragged){
-      val = offset > -(handleWidth / 2);
-      val = inverse ? !val : val;
+    	val = offset > -(handleWidth / 2);
+    	val = inverse ? !val : val;
+    } else if (tristate) {
+    	val = value===null?true:(value?false:null);
+    } else {
+    	val = !value;
     }
 
     this.setState({
@@ -379,6 +387,7 @@ Switch.defaultProps = {
   disabled:       false,
   readonly:       false,
 
+  tristate:		  false,
   defaultValue:   true,
   value:          undefined
 };
@@ -410,6 +419,7 @@ Switch.propTypes = {
   disabled:       React.PropTypes.bool,
   readonly:       React.PropTypes.bool,
 
+  tristate:       React.PropTypes.bool,
   defaultValue:   React.PropTypes.bool,
   value:          React.PropTypes.bool,
   onChange:       React.PropTypes.func,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -228,7 +228,7 @@ export default class Switch extends React.Component {
     	val = offset > -(handleWidth / 2);
     	val = inverse ? !val : val;
     } else if (tristate) {
-    	val = value===null?true:(value?false:null);
+    	val = value===null?true:null;
     } else {
     	val = !value;
     }


### PR DESCRIPTION
Wanted to use the switch as a tristate for filters - ie "only show those items with a feature", "only show those items without a feature", "don't filter on the feature".

The indeterminate state got close, but the user needed to be able to select back to that null state. Now, if the tristate={true} parameter is set, this can happen.
