### PR TITLE
Fix for 'NaN' is an invalid value for the 'marginLeft' css

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -135,7 +135,9 @@ export default class Switch extends React.Component {
 
     let newOffset = offset;
 
-    if (value === null) {
+    if(handleWidth === 'auto') {
+      newOffset = 0;
+    } else if (value === null) {
       newOffset = -(handleWidth / 2);
     } else if (value) {
       newOffset = inverse ? -handleWidth : 0;


### PR DESCRIPTION
_updateContainerPosition should care about handleWidth 'auto' value to
prevent error `NaN` is an invalid value for the `marginLeft` css style property