### PR TITLE
Support React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "typings": "dist/typings/index.d.ts",
   "peerDependencies": {
     "prop-types": "^15.5.0",
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0"
+    "react": ">=15.5.0",
+    "react-dom": ">=15.5.0"
   },
   "repository": {
     "type": "git",
@@ -49,9 +49,9 @@
     "gulp-util": "^3.0.3",
     "output-file-sync": "^1.1.2",
     "prop-types": "^15.5.8",
-    "react": "^15.0.0",
-    "react-bootstrap": "^0.30.3",
-    "react-dom": "^15.0.0",
+    "react": "^16.0.0",
+    "react-bootstrap": "^0.31.3",
+    "react-dom": "^16.0.0",
     "reactify": "^1.1.1",
     "vinyl-source-stream": "^1.0.0",
     "watchify": "^3.9.0"


### PR DESCRIPTION
After bumping version we should change [Version Compatability](https://github.com/Julusian/react-bootstrap-switch#version-compatability).