### PR TITLE
Fixes to convert to React componentDidUpdate and remove warning

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -22,18 +22,17 @@ export default class Switch extends React.Component {
     this._recalculateWidth();
   }
 
-  componentWillReceiveProps(nextProps){
-    const newValue = nextProps.value !== undefined ? nextProps.value : this.state.value;
-    const oldValue = this.state.value;
+  componentDidUpdate(prevProps, prevState){
+    const { value, labelWidth, handleWidth } = this.props
+    const { value: oldValue, labelWidth: oldLabelWidth, handleWidth: oldHandleWidth } = this.state
+    const newValue = value !== undefined ? value : oldValue;
 
     // ensure width is updated
-    this.setState({
-      labelWidth: nextProps.labelWidth,
-      handleWidth: nextProps.handleWidth,
-      value: newValue
-    }, () => {
-      this._recalculateWidth(newValue == oldValue);
-    });
+    if (value !== oldValue || labelWidth !== oldLabelWidth || handleWidth !== oldHandleWidth) {
+      this.setState({ labelWidth, handleWidth, value }, () => {
+        this._recalculateWidth(newValue == oldValue);
+      });
+    }
   }
 
   _getValue(){


### PR DESCRIPTION
This should get rid of the React warning: 

```
componentWillReceiveProps has been renamed, and is not recommended for use.
```

FYI I could not figure out the gulp build because this package is using an older version - but if someone can build using this PR, it should work.  You might want to update the minimum react version to 16.9 or something more recent also.